### PR TITLE
Features: Save tags, ask on error, print each torrent

### DIFF
--- a/gazelleorigin/__main__.py
+++ b/gazelleorigin/__main__.py
@@ -38,7 +38,6 @@ parser.add_argument('--post', '-p', nargs='+', metavar='file', default=[], help=
                     'These scripts have access to environment variables with info about the item including OUT, ARTIST, NAME, DIRECTORY, EDITION, YEAR, FORMAT, ENCODING')
 parser.add_argument('--recursive', '-r', action='store_true', help='recursively search directories for files')
 parser.add_argument('--no-hash', '-n', action='store_true', help='don\'t compute hash from torrent files')
-# parser.add_argument('--ignore-invalid', '-i', action='store_true', help='continue processing other arguments if an invalid id/hash is supplied')
 parser.add_argument(
     "--ignore-invalid",
     "-i",

--- a/gazelleorigin/__main__.py
+++ b/gazelleorigin/__main__.py
@@ -59,11 +59,15 @@ environment = {}
 def ask_invalid():
     """Prompt the user for the next action after encoutnering an error."""
     do_this = ""
-    options_ask = ["skip", "stop"]
+    options_ask = ["c", "s"]
     while do_this not in options_ask:
-        print("Error. STOP the entire program or SKIP this error?")
+        print("Error. (s)top the entire program or (c)ontinue from this error?")
         print("Options (lowercase) = {}".format(options_ask))
         do_this = input("Your choice: ")
+    if do_this == 'c':
+        do_this = "continue"
+    elif do_this == 's':
+        do_this = 'stop'
     return do_this
 
 
@@ -194,6 +198,7 @@ Get torrent's info from GazelleAPI
 torrent can be an id, hash, url, or path
 """
 def handle_input_torrent(torrent, walk=True, recursive=False):
+    print("Handling {}".format(torrent))
     parsed = parse_torrent_input(torrent, walk, recursive)
     if parsed == 'walked':
         return

--- a/gazelleorigin/__main__.py
+++ b/gazelleorigin/__main__.py
@@ -74,6 +74,8 @@ def handle_invalid():
     elif args.ignore_invalid == "ask":
         result = ask_invalid()
         return result
+    else:
+        return 'stop'
 
 
 def main():
@@ -132,7 +134,8 @@ def main():
         api = GazelleAPI(environment['api_key'])
     except GazelleAPIError as e:
         print('Error initializing Gazelle API client')
-        sys.exit(EXIT_CODES[e.code])
+        if handle_invalid() == "stop":
+            sys.exit(EXIT_CODES[e.code])
 
     for arg in args.torrent:
         handle_input_torrent(arg, True, args.recursive)

--- a/gazelleorigin/core.py
+++ b/gazelleorigin/core.py
@@ -3,7 +3,7 @@ import json
 import requests
 import textwrap
 import yaml
-
+import pdb
 
 headers = {
     'Connection': 'keep-alive',
@@ -75,6 +75,11 @@ class GazelleAPI:
         else:
             artists = 'Various Artists'
 
+        # If the api can return empty tags
+        if not 'tags' in group:
+            group['tags'] = ''
+        if group['tags'] is None:
+            group['tags'] = ''
         dict = {k:html.unescape(v) if isinstance(v, str) else v for k,v in {
             'Artist':         artists,
             'Name':           group['name'],
@@ -93,6 +98,7 @@ class GazelleAPI:
             'Info hash':      torrent['infoHash'],
             'Uploaded':       torrent['time'],
             'Permalink':      'https://redacted.ch/torrents.php?torrentid={0}'.format(torrent['id']),
+            'Tags':           str(', '.join(str(tag) for tag in group['tags']))
         }.items()}
 
         dump = yaml.dump(dict, width=float('inf'), sort_keys=False, allow_unicode=True)

--- a/gazelleorigin/core.py
+++ b/gazelleorigin/core.py
@@ -3,7 +3,6 @@ import json
 import requests
 import textwrap
 import yaml
-import pdb
 
 headers = {
     'Connection': 'keep-alive',


### PR DESCRIPTION
Save tags- a new line under 'permalink' for tags. looks like:

```
Tags:           electronic, ambient, minimal, japanese, new.age
```

I attempted to handle the API not returning tags, although I couldn't test it.

Ask on error: ignore-invalid has changed to allow 3 options: stop, ask, continue. most errors now check this arg.
- stop: abort (same as ignore-invalid false in your version)
- continue: continue (similar to ignore-invalid ture in your version, but with more errors caught and ignored?)
- ask: prompts the user

I didn't have it catch a gazelle api error in core.py. should be an easy fix.

print each torrent:
each time a torrent is handled, it prints:
`Handling ./mypath/myfile-001.torrent`

I wanted to include a progress counter but the recursion made it not worth my time.

I did some testing on my collection. I didn't have a chance to test the error behavior. the tags and printing seem to work fine.

I don't know how the tags will integrate with beet-originquery but I hope it's an easy fix.